### PR TITLE
always call environment.retain in lookup case

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -165,7 +165,7 @@ class ReactRelayQueryRenderer extends React.Component<Props, State> {
         if (this._pendingFetch) {
             this._pendingFetch.dispose();
         }
-        if (this._rootSubscription) {
+        if (!this.props.retain && this._rootSubscription) {
             this._rootSubscription.dispose();
         }
 
@@ -197,7 +197,7 @@ class ReactRelayQueryRenderer extends React.Component<Props, State> {
                         },
                     };
 
-                    if (this._selectionReference) {
+                    if (!this.props.retain && this._selectionReference) {
                         this._selectionReference.dispose();
                     }
                     this._rootSubscription = environment.subscribe(

--- a/src/index.js
+++ b/src/index.js
@@ -115,23 +115,22 @@ class ReactRelayQueryRenderer extends React.Component<Props, State> {
                 environment,
                 variables: operation.variables,
             };
-            if (props.lookup) {
+            if (props.lookup && environment.check(operation.root)) {
                 this._selectionReference = environment.retain(operation.root);
-                if (environment.check(operation.root)) {
-                    // data is available in the store, render without making any requests
-                    const snapshot = environment.lookup(operation.fragment);
-                    this._rootSubscription = environment.subscribe(snapshot, this._onChange);
 
-                    return {
-                        error: null,
-                        props: snapshot.data,
-                        retry: () => {
-                            this._fetch(operation, props.cacheConfig);
-                        },
-                    };
-                } else {
-                    return this._fetch(operation, props.cacheConfig) || getDefaultState();
-                }
+                // data is available in the store, render without making any requests
+                const snapshot = environment.lookup(operation.fragment);
+                this._rootSubscription = environment.subscribe(snapshot, this._onChange);
+
+                return {
+                    error: null,
+                    props: snapshot.data,
+                    retry: () => {
+                        this._fetch(operation, props.cacheConfig);
+                    },
+                };
+            } else {
+                return this._fetch(operation, props.cacheConfig) || getDefaultState();
             }
         } else {
             this._relayContext = {


### PR DESCRIPTION
I found that retain was not working as I expected when using QueryRenderer with `lookup` and `retain` set for a query with variables when variables changed. 

### Behavior
- Initial render
  - Fetches the query with initial variables
- Variables change
  - Fetches the query with new variables
- Variables change back to initial variables
  - Fetches the query again with initial variables

### Expected behavior

- Initial render
  - Fetches the query with initial variables
- Variables change
  - Fetches the query with new variables
- Variables change back to initial variables
  - Gets the data from cache

### Changes

`environment.retain(operation.root);` is always called if `lookup` is set instead of checking for both `lookup` being set and `environment.check(operation.root)`. I am not sure why this works (I guess that this prevents the subscription from being GC when `operation.root` changes due to variable changes) and if it causes unexpected changes. From what I could test on my application everything worked as I expected with `retain` both `true` and `false`.  

Last but not least, thanks for making this project. I feel like this was a regression after migrating from classic to modern.