### PR TITLE
Changes that were necessary to use with Relay 6.0

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ const React = require('react');
 const areEqual = require('fbjs/lib/areEqual');
 const deepFreeze = require('deep-freeze');
 const {ReactRelayContext} = require('react-relay');
+const {createOperationDescriptor, getRequest} = require('relay-runtime');
 
 import type {CacheConfig, Disposable} from 'RelayCombinedEnvironmentTypes';
 import type {RelayEnvironmentInterface as ClassicEnvironment} from 'RelayEnvironment';
@@ -106,14 +107,10 @@ class ReactRelayQueryRenderer extends React.Component<Props, State> {
 
         const {query, variables} = props;
         if (query) {
-            const {
-                createOperationDescriptor,
-                getRequest,
-            } = environment.unstable_internal;
             const operation = createOperationDescriptor(getRequest(query), variables);
             this._relayContext = {
                 environment,
-                variables: operation.variables,
+                variables: operation.variables || {},
             };
             if (props.lookup && environment.check(operation.root)) {
                 this._selectionReference = environment.retain(operation.root);


### PR DESCRIPTION
Relay 6.0 removed `environment.unstable_internal`, but the functions were available on `relay-runtime`. It also seemed to break if variables were missing. Not proposing this as the final PR, just an initial exploration.